### PR TITLE
Normalize SQL indentation

### DIFF
--- a/dbt/greekmpany/models/employee_count_per_department.sql
+++ b/dbt/greekmpany/models/employee_count_per_department.sql
@@ -1,10 +1,10 @@
 {{ config(materialized='view') }}
 
 SELECT
-	d.department_name,
-	COUNT(e.employee_id) AS total_employees
+ d.department_name,
+ COUNT(e.employee_id) AS total_employees
 FROM greekmpany.employee AS e
 INNER JOIN greekmpany.department AS d
-	ON e.department_id = d.department_id
+ ON e.department_id = d.department_id
 GROUP BY d.department_id
 ORDER BY total_employees DESC

--- a/ddl_scripts/generate_ddl_department.sql
+++ b/ddl_scripts/generate_ddl_department.sql
@@ -4,52 +4,52 @@ UNION ALL
 
 SELECT column_structure.text
 FROM (
-    SELECT 
-        CONCAT(
-            '    ', column_name, ' ', UPPER(column_type),
-            CASE
-                WHEN is_nullable = 'NO' THEN ' NOT NULL'
-                ELSE ''
-            END,
-            CASE
-                WHEN extra IS NOT NULL THEN CONCAT(' ', UPPER(extra))
-                ELSE ''
-            END,
-            ','
-        ) text
-    FROM information_schema.columns
-    WHERE table_schema = 'greekmpany'
-        AND table_name = 'department'
-    ORDER BY ordinal_position
+  SELECT 
+    CONCAT(
+      '    ', column_name, ' ', UPPER(column_type),
+      CASE
+        WHEN is_nullable = 'NO' THEN ' NOT NULL'
+        ELSE ''
+      END,
+      CASE
+        WHEN extra IS NOT NULL THEN CONCAT(' ', UPPER(extra))
+        ELSE ''
+      END,
+      ','
+    ) text
+  FROM information_schema.columns
+  WHERE table_schema = 'greekmpany'
+    AND table_name = 'department'
+  ORDER BY ordinal_position
 ) AS column_structure
 
 UNION ALL
 
 SELECT CONCAT(
-    '    CONSTRAINT pk_department PRIMARY KEY (',
-    (
-        SELECT column_structure.text
-        FROM (
-            SELECT CONCAT(
-                CASE 
-                    WHEN ordinal_position > 1 THEN ','
-                    ELSE ''
-                END,
-                column_name,
-                ')'
-            ) AS text
-            FROM information_schema.key_column_usage
-            WHERE table_schema = 'greekmpany'
-                AND table_name = 'department'
-                AND constraint_name = 'PRIMARY'
-            ORDER BY ordinal_position
-        ) AS column_structure
-    )
+  '    CONSTRAINT pk_department PRIMARY KEY (',
+  (
+    SELECT column_structure.text
+    FROM (
+      SELECT CONCAT(
+        CASE 
+          WHEN ordinal_position > 1 THEN ','
+          ELSE ''
+        END,
+        column_name,
+        ')'
+      ) AS text
+      FROM information_schema.key_column_usage
+      WHERE table_schema = 'greekmpany'
+        AND table_name = 'department'
+        AND constraint_name = 'PRIMARY'
+      ORDER BY ordinal_position
+    ) AS column_structure
+  )
 )
 FROM information_schema.table_constraints
 WHERE table_schema = 'greekmpany'
-    AND table_name = 'department'
-    AND constraint_type = 'PRIMARY KEY'
+  AND table_name = 'department'
+  AND constraint_type = 'PRIMARY KEY'
 
 
 UNION ALL

--- a/scripts/create_tables.sql
+++ b/scripts/create_tables.sql
@@ -1,23 +1,23 @@
 CREATE TABLE department (
-    department_id TINYINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    department_name VARCHAR(20) NOT NULL,
-    CONSTRAINT pk_department PRIMARY KEY (department_id)
+  department_id TINYINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  department_name VARCHAR(20) NOT NULL,
+  CONSTRAINT pk_department PRIMARY KEY (department_id)
 ) 
 ENGINE = InnoDB
 DEFAULT CHARSET = utf8mb4;
 
 CREATE TABLE employee (
-    employee_id TINYINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    first_name VARCHAR(40) NOT NULL,
-    last_name VARCHAR(40) NOT NULL,
-    role VARCHAR(40) NOT NULL,
-    start_date DATE NOT NULL,
-    end_date DATE,
-    department_id TINYINT UNSIGNED NOT NULL,
-    CONSTRAINT pk_employee PRIMARY KEY (employee_id),
-    CONSTRAINT fk_department_id FOREIGN KEY (department_id)
-        REFERENCES department(department_id)
-        ON DELETE RESTRICT
+  employee_id TINYINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  first_name VARCHAR(40) NOT NULL,
+  last_name VARCHAR(40) NOT NULL,
+  role VARCHAR(40) NOT NULL,
+  start_date DATE NOT NULL,
+  end_date DATE,
+  department_id TINYINT UNSIGNED NOT NULL,
+  CONSTRAINT pk_employee PRIMARY KEY (employee_id),
+  CONSTRAINT fk_department_id FOREIGN KEY (department_id)
+    REFERENCES department(department_id)
+    ON DELETE RESTRICT
 ) 
 ENGINE = InnoDB
 DEFAULT CHARSET = utf8mb4;

--- a/scripts/insert_department.sql
+++ b/scripts/insert_department.sql
@@ -1,10 +1,10 @@
 INSERT INTO department (
-    department_name
+  department_name
 ) 
 VALUES
-    ('IT'),
-    ('HR'),
-    ('Marketing'),
-    ('Sales'),
-    ('Accounting'),
-    ('Legal');
+  ('IT'),
+  ('HR'),
+  ('Marketing'),
+  ('Sales'),
+  ('Accounting'),
+  ('Legal');

--- a/scripts/insert_employee.sql
+++ b/scripts/insert_employee.sql
@@ -1,12 +1,12 @@
 INSERT INTO employee (
-    first_name,
-    last_name,
-    role,
-    start_date,
-    end_date,
-    department_id
+  first_name,
+  last_name,
+  role,
+  start_date,
+  end_date,
+  department_id
 )
 VALUES
-    ('Nikos', 'Korobos', 'Network Engineer', '2025-06-01', NULL, 1),
-    ('Manthos', 'Foustanos', 'Talent Acquisition Specialist', '2025-06-01', NULL, 2),
-    ('Erikos', 'Gikas', 'Head of Legal Affairs', '2025-06-01', NULL, 6);
+  ('Nikos', 'Korobos', 'Network Engineer', '2025-06-01', NULL, 1),
+  ('Manthos', 'Foustanos', 'Talent Acquisition Specialist', '2025-06-01', NULL, 2),
+  ('Erikos', 'Gikas', 'Head of Legal Affairs', '2025-06-01', NULL, 6);

--- a/scripts/setup.sql
+++ b/scripts/setup.sql
@@ -1,4 +1,4 @@
 CREATE DATABASE greekmpany
-    CHARACTER SET utf8mb4;
-    
+  CHARACTER SET utf8mb4;
+  
 USE greekmpany;


### PR DESCRIPTION
## Summary
- reformat SQL scripts to use two-space indentation

## Testing
- `dbt --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b8996a99c8322a83d2e23f9e54715